### PR TITLE
fix: kms credentials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export interface AwsKmsSignerCredentials {
   sessionToken?: string;
   region: string;
   keyId: string;
+  useEnv?: boolean;
 }
 export class AwsKmsSigner extends ethers.Signer {
   kmsCredentials: AwsKmsSignerCredentials;

--- a/src/util/aws-kms-utils.ts
+++ b/src/util/aws-kms-utils.ts
@@ -21,6 +21,9 @@ const EcdsaPubKey = asn1.define("EcdsaPubKey", function (this: any) {
 /* eslint-enable func-names */
 
 export async function sign(digest: Buffer, kmsCredentials: AwsKmsSignerCredentials) {
+  if (!kmsCredentials.useEnv && (!kmsCredentials.accessKeyId || !kmsCredentials.secretAccessKey)) {
+    throw new Error(`Please provide access-key-id and secret-access-key`);
+  }
   const kms = new KMS(kmsCredentials);
   const params: KMS.SignRequest = {
     // key id or 'Alias/<alias>'
@@ -35,6 +38,9 @@ export async function sign(digest: Buffer, kmsCredentials: AwsKmsSignerCredentia
 }
 
 export async function getPublicKey(kmsCredentials: AwsKmsSignerCredentials) {
+  if (!kmsCredentials.useEnv && (!kmsCredentials.accessKeyId || !kmsCredentials.secretAccessKey)) {
+    throw new Error(`Please provide access-key-id and secret-access-key`);
+  }
   const kms = new KMS(kmsCredentials);
   return kms
     .getPublicKey({


### PR DESCRIPTION
Based on testing the aws-sdk seems to take credentials from env variables unless both `access-key-id` and `secret-access-key` args are explicitly provided (not undefined or blank). 

This fix enforces that both args be provided unless --use-env flag is set