### PR TITLE
feat(endpoint): add endpoint for kms connection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export interface AwsKmsSignerCredentials {
   sessionToken?: string;
   region: string;
   keyId: string;
+  endpoint?: string;
 }
 export class AwsKmsSigner extends ethers.Signer {
   kmsCredentials: AwsKmsSignerCredentials;


### PR DESCRIPTION
## Motivation

We are going to use `local-kms` to test out our signing locally. AWS has allowed the override of the endpoint if you check out the types provided to `KMS.Types.ClientConfiguration` you will find that it is `ServiceConfigurationOptions` which provides this convenient `endpoint` parameter.

```
    /**
     * The endpoint URI to send requests to. The default endpoint is built from the configured region.
     * The endpoint should be a string like 'https://{service}.{region}.amazonaws.com' or an Endpoint object.
     */
    endpoint?: string | Endpoint;
```

Realistically there are tons of things missing from this type but it may be nice to have this one defined in there to avoid issues with `as unknown as AwsKmsSignerCredentials` or similar.

## Solution

Add the endpoint parameter as this may be a common occourance. It should provide sufficient configuration for many local testing use cases.

In the long run you may want to do something like this for the top of that file

```
import { ethers, UnsignedTransaction } from "ethers";
import { KMS } from "aws-sdk";
import { getPublicKey, getEthereumAddress, requestKmsSignature, determineCorrectV } from "./util/aws-kms-utils";

type AwsKmsSignerCredentials = KMS.Types.ClientConfiguration;
```

But that is a bigger change. I think you should still be able to get away with a minor version bump for that but its up to you.

tagging @rjchow for visibility